### PR TITLE
Fixed critical bug in DFTExtractor usage

### DIFF
--- a/obelix/descriptor_calculator.py
+++ b/obelix/descriptor_calculator.py
@@ -829,7 +829,7 @@ class Descriptors:
             # get indices of bidentate ligands and metal for descriptor calculation class
             dft_properties = {}
             try:
-                dft = DFTExtractor(metal_ligand_complex, metal_idx, bidentate_max_donor_idx, bidentate_min_donor_idx, metal_adduct)
+                dft = DFTExtractor(metal_ligand_complex, metal_idx, bidentate_min_donor_idx, bidentate_max_donor_idx, metal_adduct)
                 dft_properties = self._calculate_dft_descriptors_from_log(dft, dft_properties)
             except Exception as e:
                 # print(e)


### PR DESCRIPTION
In [this commit](https://github.com/EPiCs-group/obelix/commit/5cd51ec07a56d67bb6cf1a4ea88587aab4b23437 the numbering of min/max donors for DFT descriptor extraction were accidentally reversed. This meant that the mulliken/NBO charge on donors were reversed. This was checked by comparing the extracted values resulting from obelix with the values in the log files.