### PR TITLE
Setup automated testing using GitHub Actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,6 +44,9 @@ jobs:
        # Additionally, install pytest via mamba to run tests.
       run: mamba env update -n obelix -f environment.yml && mamba install -n obelix pytest -y
 
+    - name: Verify pytest installation
+      run: mamba list -n obelix | grep pytest
+
     - name: Test with pytest
       run: python -m pytest -v
       # `python -m pytest` is almost equivalent to invoking the command line

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Install dependencies
        # This step installs the dependencies listed in the environment.yml file. Some dependencies are available only via conda, so environment.yml is preferred over requirements.txt or pyproject.toml.
-      run: mamba env update --file environment.yml && mamba install pytest
+      run: mamba env update --file environment.yml && mamba install pytest -y
 
     - name: Test with pytest
       run: python -m pytest -v

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,9 +18,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12"]
-        include:
-            - os: macos-latest
-              python-version: "3.10"
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,7 +48,7 @@ jobs:
       run: mamba list -n obelix | grep pytest
 
     - name: Test with pytest
-      run: python -m pytest -v
+      run: mamba run -n obelix python -m pytest -v
       # `python -m pytest` is almost equivalent to invoking the command line
       # script pytest [...] directly, except that calling via python will also # add the current directory to sys.path. Since we do not opt to install # obelix package in development mode, obelix/ must be present in
       # sys. path for the tests to be able to import obelix/.

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,51 @@
+# GitHub Actions workflow to run tests upon push or pull request to the main branch. The workflow runs on Ubuntu, macOS, and Windows operating systems with Python versions 3.10, 3.11, and 3.12. The workflow sets up a conda environment using mamba, installs dependencies listed in the environment.yml file, and runs tests with pytest.
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+
+name: Run tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10", "3.11", "3.12"]
+        include:
+            - os: macos-latest
+              python-version: "3.10"
+            - os: windows-latest
+              python-version: "3.10"
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Setup conda environment using mamba
+        # This step sets up a conda environment using mamba, a faster alternative to conda. It creates an empty conda environment with the name 'obelix' and activates it. The environment is created using the latest version of Mambaforge, a conda distribution that includes mamba.
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+           miniforge-variant: Mambaforge
+           miniforge-version: latest
+           activate-environment: obelix
+           use-mamba: true
+
+    - name: Install dependencies
+       # This step installs the dependencies listed in the environment.yml file. Some dependencies are available only via conda, so environment.yml is preferred over requirements.txt or pyproject.toml.
+      run: mamba env update --file environment.yml && mamba install pytest
+
+    - name: Test with pytest
+      run: pytest -v
+
+

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,6 +46,10 @@ jobs:
       run: mamba env update --file environment.yml && mamba install pytest
 
     - name: Test with pytest
-      run: pytest -v
+      run: python -m pytest -v
+      # `python -m pytest` is almost equivalent to invoking the command line
+      # script pytest [...] directly, except that calling via python will also # add the current directory to sys.path. Since we do not opt to install # obelix package in development mode, obelix/ must be present in
+      # sys. path for the tests to be able to import obelix/.
+      # The -v flag prints the pass/fail status of testcases along with the iinput each test case is run with.
 
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -40,9 +40,6 @@ jobs:
        # This step installs the dependencies listed in the environment.yml file. Some dependencies are available only via conda, so environment.yml is preferred over requirements.txt or pyproject.toml.
        # Additionally, install pytest via mamba to run tests.
       run: mamba env update -n obelix -f environment.yml && mamba install -n obelix pytest -y
-
-    - name: Verify pytest installation
-      run: mamba list -n obelix | grep pytest
 
     - name: Test with pytest
       run: mamba run -n obelix python -m pytest -v

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         python-version: ["3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,8 @@ jobs:
 
     - name: Install dependencies
        # This step installs the dependencies listed in the environment.yml file. Some dependencies are available only via conda, so environment.yml is preferred over requirements.txt or pyproject.toml.
-      run: mamba env update --file environment.yml && mamba install pytest -y
+       # Additionally, install pytest via mamba to run tests.
+      run: mamba env update -n obelix -f environment.yml && mamba install -n obelix pytest -y
 
     - name: Test with pytest
       run: python -m pytest -v

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,8 +21,6 @@ jobs:
         include:
             - os: macos-latest
               python-version: "3.10"
-            - os: windows-latest
-              python-version: "3.10"
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
 - ase==3.22.1
 - openbabel==3.1.1
 - pandas==1.4.3
-- numpy==1.23.2
+- numpy<2.0.0
 - rdkit==2022.09.1
 - morfeus-ml==0.7.1
 - mordred==1.2.0


### PR DESCRIPTION
- Closes #21 
- Run tests on pull request and push to main
- Despite numpy being pinned to 1.23.2, some other dependencies in the environment.yml require newer version of numpy and ends up installing numpy version>2.0.0 which is not compatible with the code. To counter this, numpy<2.0.0. is specified in environment.yml