### PR TITLE
GitHub actions workflow to build and publish docs to github pages

### DIFF
--- a/.github/workflows/build_and_publish_docs.yml
+++ b/.github/workflows/build_and_publish_docs.yml
@@ -1,0 +1,31 @@
+# This workflow builds and publishes the documentation to GitHub Pages
+# Source: https://coderefinery.github.io/documentation/gh_workflow/#exercise-deploy-sphinx-documentation-to-github-pages
+
+
+name: Build and publish docs
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - name: Install dependencies
+        run: |
+          pip install -r docs/requirements.txt
+      - name: Sphinx build
+        run: |
+          sphinx-build docs/ _build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          force_orphan: true

--- a/.github/workflows/build_and_publish_docs.yml
+++ b/.github/workflows/build_and_publish_docs.yml
@@ -1,5 +1,7 @@
 # This workflow builds and publishes the documentation to GitHub Pages
-# Source: https://coderefinery.github.io/documentation/gh_workflow/#exercise-deploy-sphinx-documentation-to-github-pages
+# This workflow is sourced from https://coderefinery.github.io/documentation/gh_workflow/#exercise-deploy-sphinx-documentation-to-github-pages available
+# under CC BY 4.0 license https://creativecommons.org/licenses/by/4.0/
+# The file paths in the Install dependencies step and Sphinx build step are adjusted to match the file structure of this repository.
 
 
 name: Build and publish docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+sphinx-rtd-theme
+sphinx-autoapi
+myst-parser


### PR DESCRIPTION
On every commit to main, docs inside `docs/` are built and then deployed on github pages.

Closes #33 

After this PR is merged, deployment of the docs on GitHub pages can be enabled in the following steps:
- Go to Settings>Pages
- Choose Deploy from branch and select gh-pages and root/ in the menu
- The URL where the docs will be published will be displayed thereafter